### PR TITLE
Update status for tests on jsshell.

### DIFF
--- a/.status
+++ b/.status
@@ -20,3 +20,6 @@ build/test/*/*/*/*: SkipByDesign
 [ $compiler == dart2analyzer ]
 test/game_test: StaticWarning # pkg/bot issues with Coordinate and Vector
 test/field_test: StaticWarning # pkg/bot issues with Coordinate and Vector
+
+[ $runtime == jsshell ]
+*: Skip # uses package:test which has non-zero timers


### PR DESCRIPTION
Jsshell doesn't support the timers with non-zero delay, used by package:test's heartbeat.