### PR TITLE
rename `time` to `timeInSeconds`

### DIFF
--- a/lib/src/stage/score_element.dart
+++ b/lib/src/stage/score_element.dart
@@ -21,10 +21,10 @@ class ScoreElement extends TextField implements Animatable {
 
   @override
   bool advanceTime(num time) {
-    var time = (game.duration == null)
+    var timeInSeconds = (game.duration == null)
         ? '0'
         : (game.duration.inMilliseconds / 1000).toStringAsFixed(1);
-    text = 'Bombs Left: ${game.bombsLeft}\nTime: $time';
+    text = 'Bombs Left: ${game.bombsLeft}\nTime: $timeInSeconds';
     if (bestTime > 0) {
       text = text + '\nRecord: ${(bestTime/1000).toStringAsFixed(1)}';
     }


### PR DESCRIPTION
It previously was conflicting with the parameter.