### PR TITLE
Make sure we always have a Point<int>

### DIFF
--- a/lib/src/game/game.dart
+++ b/lib/src/game/game.dart
@@ -92,18 +92,18 @@ class Game {
     return false;
   }
 
-  List<Point> reveal(int x, int y) {
+  List<Point<int>> reveal(int x, int y) {
     _ensureStarted();
     require(canReveal(x, y), "Item cannot be revealed.");
     final currentSS = _states.get(x, y);
 
-    List<Point> reveals;
+    List<Point<int>> reveals;
 
     // normal reveal
     if (currentSS == SquareState.hidden) {
       if (field.get(x, y)) {
         _setLost();
-        reveals = <Point>[];
+        reveals = <Point<int>>[];
       } else {
         reveals = _doReveal(x, y);
       }
@@ -188,7 +188,7 @@ class Game {
     return false;
   }
 
-  List<Point> _doChord(int x, int y) {
+  List<Point<int>> _doChord(int x, int y) {
     // this does not repeat a bunch of validations that have already happened
     // be careful
     final currentSS = _states.get(x, y);
@@ -215,7 +215,7 @@ class Game {
     // for now we assume counts have been checked
     assert(flagged.length == adjCount);
 
-    var reveals = <Point>[];
+    var reveals = <Point<int>>[];
 
     // if any of the hidden are bombs, we've failed
     if (failed) {
@@ -232,12 +232,12 @@ class Game {
     return reveals;
   }
 
-  List<Point> _doReveal(int x, int y) {
+  List<Point<int>> _doReveal(int x, int y) {
     assert(_states.get(x, y) == SquareState.hidden);
     _states.set(x, y, SquareState.revealed);
     _revealsLeft--;
     assert(_revealsLeft >= 0);
-    var reveals = <Point>[new Point(x, y)];
+    var reveals = [new Point(x, y)];
     if (_revealsLeft == 0) {
       _setWon();
     } else if (field.getAdjacentCount(x, y) == 0) {

--- a/lib/src/stage/game_element.dart
+++ b/lib/src/stage/game_element.dart
@@ -132,7 +132,7 @@ class GameElement extends Sprite {
     assert(!game.gameEnded);
     final ss = game.getSquareState(x, y);
 
-    List<Point> reveals;
+    List<Point<int>> reveals;
 
     if (alt) {
       if (ss == SquareState.hidden || ss == SquareState.flagged) {
@@ -154,7 +154,7 @@ class GameElement extends Sprite {
       }
     } else {
       if (ss == SquareState.hidden) {
-        _startDartAnimation(<Point>[new Point(x, y)]);
+        _startDartAnimation([new Point(x, y)]);
         reveals = game.reveal(x, y);
       }
     }
@@ -191,7 +191,8 @@ class GameElement extends Sprite {
     return false;
   }
 
-  void _startPopAnimation(Point start, [Iterable<Point> reveals = null]) {
+  void _startPopAnimation(Point<int> start,
+      [Iterable<Point<int>> reveals = null]) {
     if (reveals == null) {
       assert(game.state == GameState.lost);
 
@@ -202,7 +203,7 @@ class GameElement extends Sprite {
           .where((t2) =>
               t2.item2 == SquareState.bomb || t2.item2 == SquareState.hidden)
           .map((t2) => t2.item1)
-          .toList() as List<Point>;
+          .toList() as List<Point<int>>;
     }
 
     final values = reveals.map((c) {


### PR DESCRIPTION
In the latest sdk I am getting some strong mode runtime errors due to the use of `Point` instead of an explicit `Point<int>`. This was leading to errors when creating the `_Values` object that requires a `Point<int>` [here](https://github.com/dart-lang/sample-pop_pop_win/blob/c192014de0f1610857be86e51407fbd35104cc85/lib/src/stage/game_element.dart#L216).

I am not sure exactly what changed to make this just now start being an issue, cc @vsmenon @leafpetersen.