### PR TITLE
Guarantee Safe First Click & Improve Bomb Placement

### DIFF
--- a/lib/src/game/field.dart
+++ b/lib/src/game/field.dart
@@ -32,6 +32,42 @@ class Field extends Array2d<bool> {
     return Field._internal(bombCount, cols, squares);
   }
 
+  /// Creates a field with a guaranteed safe position at (safeX, safeY)
+  /// This ensures the first click in Minesweeper is never a bomb
+  factory Field.withSafePosition(
+    int bombCount,
+    int cols,
+    int rows,
+    int safeX,
+    int safeY, [
+    int? seed,
+  ]) {
+    final squares = List<bool>.filled(rows * cols, false);
+    assert(bombCount < squares.length);
+    assert(bombCount > 0);
+    assert(safeX >= 0 && safeX < cols);
+    assert(safeY >= 0 && safeY < rows);
+
+    final rnd = Random(seed);
+    final safeIndex = safeY * cols + safeX;
+
+    // create a list of all valid positions (excluding safe position)
+    final availablePositions = <int>[];
+    for (int i = 0; i < squares.length; i++) {
+      if (i != safeIndex) {
+        availablePositions.add(i);
+      }
+    }
+
+    // Shuffle the available positions and place bombs in first X positions
+    availablePositions.shuffle(rnd);
+    for (int i = 0; i < bombCount; i++) {
+      squares[availablePositions[i]] = true;
+    }
+
+    return Field._internal(bombCount, cols, squares);
+  }
+
   factory Field.fromSquares(int cols, int rows, List<bool> squares) {
     assert(cols > 0);
     assert(rows > 0);

--- a/lib/src/game_manager.dart
+++ b/lib/src/game_manager.dart
@@ -37,8 +37,8 @@ abstract class GameManager {
   }
 
   void _newGame() {
-    final f = Field(_bombCount, _width, _height);
-    _game = Game(f);
+    // Pass dimensions - let Game handle field creation lazily
+    _game = Game(_width, _height, _bombCount);
     _gameStateChangedSub = _game.stateChanged.listen(_gameStateChanged);
   }
 

--- a/lib/src/game_storage.dart
+++ b/lib/src/game_storage.dart
@@ -19,9 +19,9 @@ class GameStorage {
   bool updateBestTime(Game game) {
     assert(game.state == GameState.won);
 
-    final w = game.field.width;
-    final h = game.field.height;
-    final m = game.field.bombCount;
+    final w = game.width;
+    final h = game.height;
+    final m = game.bombCount;
     final duration = game.duration!.inMilliseconds;
 
     final key = _getKey(w, h, m);

--- a/lib/src/stage/board_element.dart
+++ b/lib/src/stage/board_element.dart
@@ -16,11 +16,9 @@ class BoardElement extends Sprite {
     addTo(gameElement);
 
     final scaledSize = SquareElement.size * _boardScale;
-    _elements = Array2d<SquareElement>(game.field.width, game.field.height, (
-      i,
-    ) {
-      final x = i % game.field.width;
-      final y = i ~/ game.field.height;
+    _elements = Array2d<SquareElement>(game.width, game.height, (i) {
+      final x = i % game.width;
+      final y = i ~/ game.width;
       return SquareElement(x, y)
         ..x = x * scaledSize
         ..y = y * scaledSize

--- a/lib/src/stage/game_background_element.dart
+++ b/lib/src/stage/game_background_element.dart
@@ -82,7 +82,7 @@ class GameBackgroundElement extends Sprite {
       );
     final tbr = Rectangle<int>(0, 0, 80, 112);
     final lrr = Rectangle<int>(0, 0, 112, 80);
-    for (var i = 0; i < _game.field.width - 2; i++) {
+    for (var i = 0; i < _game.width - 2; i++) {
       boardData
         ..drawPixels(
           op.getBitmapData('game_board_side_top'),

--- a/lib/src/stage/game_element.dart
+++ b/lib/src/stage/game_element.dart
@@ -56,7 +56,7 @@ class GameElement extends Sprite {
     final sta = resourceManager.getTextureAtlas('static');
     _animations = resourceManager.getTextureAtlas('animated');
 
-    _boardSize = game.field.width * SquareElement.size + 2 * _edgeOffset;
+    _boardSize = game.width * SquareElement.size + 2 * _edgeOffset;
     _boardScale = _backgroundHoleSize / _boardSize;
 
     GameBackgroundElement(this, opa);


### PR DESCRIPTION


## What this PR changes

- Implements  field generation in the `Game` class to guarantee the first click is never a bomb (standard Minesweeper behavior).
- Adds a new `Field.withSafePosition()` factory using an efficient O(n) shuffle algorithm for bomb placement, replacing the old do-while loop.
- (`game.width`, `game.height`, `game.bombCount`) instead of accessing `game.field` before the field is generated.

## Why

- Prevents the user from losing on the first click, matching expected Minesweeper behavior.


## Issues

- Fixes:   #19 

---

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.

